### PR TITLE
Feature/fix rich assets precompile

### DIFF
--- a/lib/tasks/rich_tasks.rake
+++ b/lib/tasks/rich_tasks.rake
@@ -2,7 +2,7 @@ require 'fileutils'
 
 desc "Create nondigest versions of all ckeditor digest assets"
 task "assets:precompile" do
-  fingerprint = /\-[0-9a-f]{32}\./
+  fingerprint = /\-[0-9a-f]{32}\.|\-[0-9a-f]{64}\./
   for file in Dir["public/assets/ckeditor/**/*"]
     next unless file =~ fingerprint
     nondigest = file.sub fingerprint, '.'
@@ -11,13 +11,13 @@ task "assets:precompile" do
 end
 
 namespace :rich do
-      
+
   desc "Re-generate image styles"
   task :refresh_assets => :environment do
     # re-generate images
     ENV['CLASS'] = "Rich::RichFile"
     Rake::Task["paperclip:refresh"].invoke
-    
+
     # re-generate uri cache
     Rich::RichFile.find_each(&:save)
   end


### PR DESCRIPTION
Fix rich rake task assets:precompile, to use with new version of sprockets 3.*, which use fingerprints 64 chars length
